### PR TITLE
ENH Linux implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 
 install:
   - conda update --yes conda
-  - conda create -n testenv --yes numpy scipy "pillow<3" nose pip python=$TRAVIS_PYTHON_VERSION
+  - conda create -n testenv --yes numpy nose python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   - python setup.py build_ext install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+sudo: false
+
+python:
+  - 2.7
+  - 3.4
+
+install:
+  - conda update --yes conda
+  - conda create -n testenv --yes numpy scipy "pillow<3" nose pip python=$TRAVIS_PYTHON_VERSION
+  - source activate testenv
+  - python setup.py build_ext install
+
+
+before_install:
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; 
+    then 
+        wget http://repo.continuum.io/miniconda/Miniconda-3.7.3-Linux-x86_64.sh -O miniconda.sh; 
+    else 
+        wget http://repo.continuum.io/miniconda/Miniconda3-3.7.3-Linux-x86_64.sh -O miniconda.sh; 
+    fi
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b -p /home/travis/mc
+  - export PATH=/home/travis/mc/bin:$PATH
+
+script: nosetests --nologcapture

--- a/pims_nd2/ND2SDK.py
+++ b/pims_nd2/ND2SDK.py
@@ -8,7 +8,7 @@ if platform == "linux" or platform == "linux2":
     nd2 = cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), 'ND2SDK',
                                         'linux', 'libnd2ReadSDK.so'))
     def jdn_to_datetime(jdn):
-        return datetime.fromtimestamp(jdn)
+        return None  # ND2SDK gives no timestamp on linux
 elif platform == "darwin":
    raise OSError("Unsupported OS. The ND2SDK for OSX is included, "
                  "please try to implement!")

--- a/pims_nd2/ND2SDK.py
+++ b/pims_nd2/ND2SDK.py
@@ -7,6 +7,8 @@ from datetime import datetime
 if platform == "linux" or platform == "linux2":
     nd2 = cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), 'ND2SDK',
                                         'linux', 'libnd2ReadSDK.so'))
+    def jdn_to_datetime(jdn):
+        return datetime.fromtimestamp(jdn)
 elif platform == "darwin":
    raise OSError("Unsupported OS. The ND2SDK for OSX is included, "
                  "please try to implement!")
@@ -20,6 +22,9 @@ elif platform == "win32":
        raise OSError("The bitsize does not equal 32 or 64.")
     os.environ["PATH"] += os.pathsep + os.path.join(dlldir)
     nd2 = cdll.LoadLibrary('v6_w32_nd2ReadSDK.dll')
+
+    def jdn_to_datetime(jdn):
+        return datetime.fromtimestamp((jdn - 2440587.5) * 86400.)
 
 
 LIMFILEHANDLE = c_int
@@ -67,10 +72,6 @@ LIM_ERR = {0:  'LIM_OK',
 
 image_type = {0: 'normal', 1: 'spectral'}
 compression_type = {0: 'lossless', 1: 'lossy', 2: None}
-
-
-def jdn_to_datetime(jdn):
-    return(datetime.fromtimestamp((jdn - 2440587.5) * 86400.))
 
 
 def rgb_int_to_float_tuple(rgb):

--- a/pims_nd2/ND2SDK.py
+++ b/pims_nd2/ND2SDK.py
@@ -1,23 +1,25 @@
 from ctypes import (c_int, c_wchar, c_wchar_p, c_uint, c_size_t, c_void_p,
                     c_double, cdll, Structure, sizeof, POINTER)
 import os
+from sys import platform
 from datetime import datetime
 
-if os.name != 'nt':
-    raise OSError("Unsupported OS. The SDK for OSX and linux are included, "
-                  "please try implementing them!")
-
-bitsize = sizeof(c_void_p) * 8
-
-if bitsize == 32:
-    dlldir = os.path.join(os.path.dirname(__file__), 'ND2SDK', 'win', 'x86')
-elif bitsize == 64:
-    dlldir = os.path.join(os.path.dirname(__file__), 'ND2SDK', 'win', 'x64')
-else:
-    raise OSError("The bitsize does not equal 32 or 64.")
-
-os.environ["PATH"] += ';' + os.path.join(dlldir)
-nd2 = cdll.LoadLibrary('v6_w32_nd2ReadSDK.dll')
+if platform == "linux" or platform == "linux2":
+    nd2 = cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), 'ND2SDK',
+                                        'linux', 'libnd2ReadSDK.so'))
+elif platform == "darwin":
+   raise OSError("Unsupported OS. The ND2SDK for OSX is included, "
+                 "please try to implement!")
+elif platform == "win32":
+    bitsize = sizeof(c_void_p) * 8
+    if bitsize == 32:
+       dlldir = os.path.join(os.path.dirname(__file__), 'ND2SDK', 'win', 'x86')
+    elif bitsize == 64:
+       dlldir = os.path.join(os.path.dirname(__file__), 'ND2SDK', 'win', 'x64')
+    else:
+       raise OSError("The bitsize does not equal 32 or 64.")
+    os.environ["PATH"] += os.pathsep + os.path.join(dlldir)
+    nd2 = cdll.LoadLibrary('v6_w32_nd2ReadSDK.dll')
 
 
 LIMFILEHANDLE = c_int

--- a/pims_nd2/test.py
+++ b/pims_nd2/test.py
@@ -140,6 +140,13 @@ class TestND2(_image_series, _image_stack, _image_multichannel,
         assert_almost_equal(self.v.calibration, 0.167808983)
         assert_allclose(self.v.colors[0], [0.47, 0.91, 0.06], atol=0.01)
 
+    def test_time(self):
+        time = self.v.metadata['time_start']
+        print(self.v._lim_metadata_desc.dTimeStart)
+        assert_equal((time.year, time.month, time.day, time.hour, time.minute,
+                      time.second, time.microsecond),
+                     (2014, 6, 18, 15, 55, 23, 392018))
+
     def test_metadata_framewise(self):
         self.v.bundle_axes = 'yx'
         frame = self.v[0]

--- a/pims_nd2/test.py
+++ b/pims_nd2/test.py
@@ -21,7 +21,7 @@ def assert_image_equal(actual, expected):
         assert_allclose(actual, expected, atol=1/256.)
 
 
-class _image_single(unittest.TestCase):
+class _image_single(object):
     def check_skip(self):
         pass
 
@@ -88,7 +88,7 @@ class _image_series(_image_single):
         list(self.v[[0, -1]])
 
 
-class _image_stack(unittest.TestCase):
+class _image_stack(object):
     def check_skip(self):
         pass
 
@@ -101,7 +101,7 @@ class _image_stack(unittest.TestCase):
         assert_equal(self.v.sizes['z'], self.expected_Z)
 
 
-class _image_multichannel(unittest.TestCase):
+class _image_multichannel(object):
     def check_skip(self):
         pass
 
@@ -120,7 +120,8 @@ class _image_multichannel(unittest.TestCase):
         assert_equal(self.v.sizes['c'], self.expected_C)
 
 
-class TestND2(_image_series, _image_stack, _image_multichannel):
+class TestND2(_image_series, _image_stack, _image_multichannel,
+              unittest.TestCase):
     # Nikon NIS-Elements ND2
     # 38 x 31 pixels, 16 bits, 2 channels, 3 time points, 10 focal planes
     def setUp(self):

--- a/pims_nd2/test.py
+++ b/pims_nd2/test.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import six
 import os
+from sys import platform
 import unittest
 import nose
 import numpy as np
@@ -141,8 +142,9 @@ class TestND2(_image_series, _image_stack, _image_multichannel,
         assert_allclose(self.v.colors[0], [0.47, 0.91, 0.06], atol=0.01)
 
     def test_time(self):
+        if platform == 'linux' or platform == 'linux2':
+            raise nose.SkipTest('time_start not supported on linux. Skipping.')
         time = self.v.metadata['time_start']
-        print(self.v._lim_metadata_desc.dTimeStart)
         assert_equal((time.year, time.month, time.day, time.hour, time.minute,
                       time.second, time.microsecond),
                      (2014, 6, 18, 15, 55, 23, 392018))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup_parameters = dict(
 #        'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows :: Windows 7',
         'Operating System :: Microsoft :: Windows :: Windows Vista',
-#        'Operating System :: POSIX :: Linux',
+        'Operating System :: POSIX :: Linux',
     ],
     long_description=read('README.md'))
 


### PR DESCRIPTION
This implements the nd2 reader in linux.

@stevendbrown I think I covered your timestamp bug. On Linux, the ND2SDK returns the Unix timestamp although the documentation states that it is the JDN timestamp (which is the case on windows systems)

Could you confirm if this works?
