### PR TITLE
Modified OS checking to allow for use on OSX

### DIFF
--- a/pims_nd2/ND2SDK.py
+++ b/pims_nd2/ND2SDK.py
@@ -3,21 +3,27 @@ from ctypes import (c_int, c_wchar, c_wchar_p, c_uint, c_size_t, c_void_p,
 import os
 from datetime import datetime
 
-if os.name != 'nt':
-    raise OSError("Unsupported OS. The SDK for OSX and linux are included, "
-                  "please try implementing them!")
+if os.uname()[0] != 'Darwin':
+    if os.name != 'nt':
+        raise OSError("Unsupported OS. The SDK for OSX and linux are included, "
+                      "please try implementing them!")
 
-bitsize = sizeof(c_void_p) * 8
+    bitsize = sizeof(c_void_p) * 8
 
-if bitsize == 32:
-    dlldir = os.path.join(os.path.dirname(__file__), 'ND2SDK', 'win', 'x86')
-elif bitsize == 64:
-    dlldir = os.path.join(os.path.dirname(__file__), 'ND2SDK', 'win', 'x64')
+    if bitsize == 32:
+        dlldir = os.path.join(os.path.dirname(__file__), 'ND2SDK', 'win', 'x86')
+        dllname = "v6_w32_nd2ReadSDK.dll"
+    elif bitsize == 64:
+        dlldir = os.path.join(os.path.dirname(__file__), 'ND2SDK', 'win', 'x64')
+        dllname = "v6_w32_nd2ReadSDK.dll"
+    else:
+        raise OSError("The bitsize does not equal 32 or 64.")
 else:
-    raise OSError("The bitsize does not equal 32 or 64.")
+    dlldir = os.path.join(os.path.dirname(__file__), 'ND2SDK', 'osx', 'nd2sdk.framework')
+    dllname = "nd2sdk"
 
 os.environ["PATH"] += ';' + os.path.join(dlldir)
-nd2 = cdll.LoadLibrary('v6_w32_nd2ReadSDK.dll')
+nd2 = cdll.LoadLibrary(os.path.join(dlldir) + "/" + dllname)
 
 
 LIMFILEHANDLE = c_int


### PR DESCRIPTION
This is after moving the current `nd2sdk.framework` and `nd2ReadSDK.h` to the `ND2SDK/osx` folder but it worked fine with the prior version of the SDK with the dTimeStamp bug as well. I'm not sure why I had to add `dlldir` to the LoadLibrary call on my system but adding `dlldir` to the system path didn't work, so I did it manually. Apologies for any missteps I've made creating this PR - it's my first PR and I have no idea what I'm doing.
