### PR TITLE
Fix dll not found error

### DIFF
--- a/pims_nd2/ND2SDK.py
+++ b/pims_nd2/ND2SDK.py
@@ -19,8 +19,7 @@ elif platform == "win32":
        dlldir = os.path.join(os.path.dirname(__file__), 'ND2SDK', 'win', 'x64')
     else:
        raise OSError("The bitsize does not equal 32 or 64.")
-    os.environ["PATH"] += os.pathsep + os.path.join(dlldir)
-    nd2 = cdll.LoadLibrary('v6_w32_nd2ReadSDK.dll')
+    nd2 = cdll.LoadLibrary(os.path.join(dlldir, 'v6_w32_nd2ReadSDK.dll'))
 
 
 def jdn_to_datetime_local(jdn):

--- a/pims_nd2/nd2reader.py
+++ b/pims_nd2/nd2reader.py
@@ -271,7 +271,7 @@ class ND2_Reader(FramesSequenceND):
 
     @property
     def frame_rate(self):
-        if self._frame_rate is None:
+        if self._frame_rate is None and len(self) > 1:
             length = len(self)
             t_first = self.get_frame_2D(t=0).metadata['t_ms']
             t_last = self.get_frame_2D(t=length-1).metadata['t_ms']

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except ImportError:
 
 setup_parameters = dict(
     name="pims_nd2",
-    version="1.0-dev",
+    version="1.0",
     description="An image reader for nd2 (NIS Elements) multidimensional images",
     author="Casper van der Wel",
     install_requires=['pims>=0.3'],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except ImportError:
 
 setup_parameters = dict(
     name="pims_nd2",
-    version="1.0",
+    version="1.0-dev",
     description="An image reader for nd2 (NIS Elements) multidimensional images",
     author="Casper van der Wel",
     install_requires=['pims>=0.3'],


### PR DESCRIPTION
While importing pims_nd2 in python 3.8, I get the following error:

> c:\users\aaristov\appdata\local\programs\python\python38-32\lib\site-packages\pims_nd2\nd2reader.py in <module>
>       6 from pims.base_frames import FramesSequenceND
>       7 import os
> ----> 8 from . import ND2SDK as h
>       9 from ctypes import c_uint8, c_uint16, c_float
>      10 
> 
> c:\users\aaristov\appdata\local\programs\python\python38-32\lib\site-packages\pims_nd2\ND2SDK.py in <module>
>      21        raise OSError("The bitsize does not equal 32 or 64.")
>      22     os.environ["PATH"] += os.pathsep + os.path.join(dlldir)
> ---> 23     nd2 = cdll.LoadLibrary('v6_w32_nd2ReadSDK.dll')
>      24 
>      25 
> 
> c:\users\aaristov\appdata\local\programs\python\python38-32\lib\ctypes\__init__.py in LoadLibrary(self, name)
>     449 
>     450     def LoadLibrary(self, name):
> --> 451         return self._dlltype(name)
>     452 
>     453 cdll = LibraryLoader(CDLL)
> 
> c:\users\aaristov\appdata\local\programs\python\python38-32\lib\ctypes\__init__.py in __init__(self, name, mode, handle, use_errno, use_last_error, winmode)
>     371 
>     372         if handle is None:
> --> 373             self._handle = _dlopen(self._name, mode)
>     374         else:
>     375             self._handle = handle
> 
> FileNotFoundError: Could not find module 'v6_w32_nd2ReadSDK.dll'. Try using the full path with constructor syntax.


Adding the absolute path fixes the problem.